### PR TITLE
patch loopdev for building

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,8 @@ edition = "2021"
 [dependencies]
 sys-mount = "2.1.0"
 sysinfo = "0.29.10"
+
+
+[patch.crates-io.loopdev]
+git = "https://github.com/mulkieran/loopdev"
+branch = "bump-bindgen-reduce-version"


### PR DESCRIPTION
Patches loopdev to build when built with cargo from source on Clang 16